### PR TITLE
menu de icones no header pode ter links

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,8 @@ jQuery(document).ready(function( $ ) {
     $( "ul.toggle-bar a" ).click( function() {
         var tab_id = $( this ).attr( "data-tab" );
 
+		if (typeof(tab_id) == 'undefined') return true; 
+
         $( "ul.toggle-bar li a" ).removeClass( "current" );
         $( ".tab-content" ).removeClass( "current" );
 


### PR DESCRIPTION
Com essa modificação fica mais fácil temas que fizeram fork mudarem o comportamento dos links do header. Aqueles 3 ícones.

só tirar o valor do tab_id e aí o link passa a funcionar pra ir pra outro lugar. 

Menos coisas pra dar conflito em futuros merges
